### PR TITLE
Changed "repositories" field to "repository" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
         "type": "MIT",
         "url": "http://opensource.org/licenses/MIT"
     }],
-    "repositories": [{
+    "repository": {
         "type": "git",
         "url": "https://github.com/javascript/augment.git"
-    }],
+    },
     "dependencies": {},
     "homepage": "https://github.com/javascript/augment"
 }


### PR DESCRIPTION
This was causing a warning when downloading through NPM:

```bash
npm WARN package.json augment@4.3.0 'repositories' (plural) Not supported. Please pick one as the 'repository' field
```

Converted from a collection to a single object per package.json spec